### PR TITLE
perf:将数据库的turboModule业务逻辑切换到worker线程

### DIFF
--- a/platforms/harmony/sqlite_storage/src/main/ets/SQLitePluginPackage.ts
+++ b/platforms/harmony/sqlite_storage/src/main/ets/SQLitePluginPackage.ts
@@ -1,13 +1,16 @@
-import { RNPackage, TurboModulesFactory } from '@rnoh/react-native-openharmony/ts';
-import type { TurboModule, TurboModuleContext } from '@rnoh/react-native-openharmony/ts';
+import {
+  RNPackage,
+  WorkerTurboModuleFactory,
+  WorkerTurboModuleContext,
+  WorkerTurboModule
+ } from '@rnoh/react-native-openharmony/ts';
 import { TM } from "@rnoh/react-native-openharmony/generated/ts";
 import { SQLitePluginTurboModule } from './SQLitePluginTurboModule';
 import Logger from './Logger';
 import CommonConstants from './CommonConstants';
 
-
-class SQLitePluginTurboModulesFactory extends TurboModulesFactory {
-  createTurboModule(name: string): TurboModule | null {
+class SQLitePluginTurboModulesFactory extends WorkerTurboModuleFactory {
+  createTurboModule(name: string): WorkerTurboModule | null {
     if (name == TM.SQLitePlugin.NAME) {
       return new SQLitePluginTurboModule(this.ctx);
     }
@@ -20,7 +23,7 @@ class SQLitePluginTurboModulesFactory extends TurboModulesFactory {
 }
 
 export class SQLitePluginPackage extends RNPackage {
-  createTurboModulesFactory(ctx: TurboModuleContext): TurboModulesFactory {
+  createWorkerTurboModuleFactory(ctx: WorkerTurboModuleContext): WorkerTurboModuleFactory {
     return new SQLitePluginTurboModulesFactory(ctx);
   }
 }

--- a/platforms/harmony/sqlite_storage/src/main/ets/SQLitePluginTurboModule.ts
+++ b/platforms/harmony/sqlite_storage/src/main/ets/SQLitePluginTurboModule.ts
@@ -1,4 +1,4 @@
-import { TurboModule, TurboModuleContext } from '@rnoh/react-native-openharmony/ts';
+import { WorkerTurboModule, WorkerTurboModuleContext } from '@rnoh/react-native-openharmony/ts';
 import { TM } from '@rnoh/react-native-openharmony/generated/ts';
 import Logger from './Logger';
 import CommonConstants from './CommonConstants';
@@ -10,13 +10,13 @@ import fs, { ReadOptions } from '@ohos.file.fs';
 
 const firstWordRegex = /^(\w+)/; // 匹配字符串开头的第一个单词
 
-export class SQLitePluginTurboModule extends TurboModule implements TM.SQLitePlugin.Spec {
+export class SQLitePluginTurboModule extends WorkerTurboModule implements TM.SQLitePlugin.Spec {
   static NAME = 'SQLitePlugin';
   rdbMap: Map<string, relationalStore.RdbStore> = new Map<string, relationalStore.RdbStore>();
-  context: TurboModuleContext
+  context: WorkerTurboModuleContext
 
 
-  constructor(ctx: TurboModuleContext) {
+  constructor(ctx: WorkerTurboModuleContext) {
     super(ctx);
     this.context = ctx;
   }


### PR DESCRIPTION
# Summary

- perf:将数据库的turboModule业务逻辑切换到worker线程
- Close:#13
作为性能优化的一个要点，将后续可能的数据库耗时操作切换到worker线程，不阻塞主线程

## Test Plan

![image](https://github.com/user-attachments/assets/f2590896-c783-4386-8ec2-fa4e98467838)

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
